### PR TITLE
bumped versions to pdns-4.8.3 & alpine-3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.15 as base
+FROM alpine:3.18 as base
 
-ENV REFRESHED_AT="2022-03-25" \
-    POWERDNS_VERSION="4.6.1" \
+ENV REFRESHED_AT="2023-10-20" \
+    POWERDNS_VERSION="4.8.3" \
     BUILD_DEPS="g++ make mariadb-dev postgresql-dev sqlite-dev curl boost-dev mariadb-connector-c-dev" \
     RUN_DEPS="bash libpq sqlite-libs libstdc++ libgcc mariadb-client postgresql-client sqlite mariadb-connector-c lua-dev curl-dev boost-program_options" \
     POWERDNS_MODULES="bind gmysql gpgsql gsqlite3"
@@ -37,15 +37,15 @@ ENV AUTOCONF=mysql \
     MYSQL_PASS="root" \
     MYSQL_DB="pdns" \
     MYSQL_DNSSEC="no" \
-    MYSQL_VERSION="4.3.0" \
+    MYSQL_VERSION="4.7.0" \
     PGSQL_HOST="postgres" \
     PGSQL_PORT="5432" \
     PGSQL_USER="postgres" \
     PGSQL_PASS="postgres" \
     PGSQL_DB="pdns" \
-    PGSQL_VERSION="4.3.0" \
+    PGSQL_VERSION="4.7.0" \
     SQLITE_DB="pdns.sqlite3" \
-    SQLITE_VERSION="4.3.1" \
+    SQLITE_VERSION="4.7.0" \
     SCHEMA_VERSION_TABLE="_schema_version"
 
 EXPOSE 53/tcp 53/udp


### PR DESCRIPTION
Bump versions to:
- Alpine 3.18
- PowerDNS 4.8.3
- SQL migrations 4.7.0