### PR TITLE
bumped versions to pdns-4.9.2 & alpine-3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.18 as base
+FROM alpine:3.20 as base
 
-ENV REFRESHED_AT="2023-10-20" \
-    POWERDNS_VERSION="4.8.3" \
+ENV REFRESHED_AT="2024-10-29" \
+    POWERDNS_VERSION="4.9.2" \
     BUILD_DEPS="g++ make mariadb-dev postgresql-dev sqlite-dev curl boost-dev mariadb-connector-c-dev" \
     RUN_DEPS="bash libpq sqlite-libs libstdc++ libgcc mariadb-client postgresql-client sqlite mariadb-connector-c lua-dev curl-dev boost-program_options" \
     POWERDNS_MODULES="bind gmysql gpgsql gsqlite3"


### PR DESCRIPTION
Bump versions to:
- Alpine 3.20
- PowerDNS 4.9.2